### PR TITLE
Remove non-existing dependency "utils.h"

### DIFF
--- a/src/field.c
+++ b/src/field.c
@@ -1,5 +1,4 @@
 #include "field.h"
-#include "utils.h"
 
 #include <string.h>  /* memset */
 


### PR DESCRIPTION
Remove the dependency "utils.h", which was probably used for testing. As it doesn't exist anymore, the compilation fails, unless the line is removed